### PR TITLE
Improve short status wording

### DIFF
--- a/includes/localci-functions.php
+++ b/includes/localci-functions.php
@@ -58,9 +58,12 @@ function localci_generate_coverage_summary( $num_strings, $new_strings = 0, $per
 		case $percent_translated > 25:
 			$summary .= "{$percent_translated}% already translated.";
 			break;
+		case $percent_translated <= 25 && $num_strings > $warning_threshold:
+			$summary .= "Only {$percent_translated}% already translated.";
+			break;
 		case $percent_translated <= 25:
-			$prefix = ( $num_strings > $warning_threshold ) ? ' Only ' : '';
-			$summary .= $prefix . "{$percent_translated}% already translated.";
+			$summary .= "{$percent_translated}% already translated.";
+			break;
 		case $percent_translated === '0':
 			$summary .= "Nothing translated yet.";
 	}

--- a/includes/localci-functions.php
+++ b/includes/localci-functions.php
@@ -55,17 +55,15 @@ function localci_generate_coverage_summary( $num_strings, $new_strings = 0, $per
 		case '100' === $percent_translated :
 			$summary .= 'Everything already translated!';
 			break;
-		case $percent_translated > 25:
-			$summary .= "{$percent_translated}% already translated.";
-			break;
-		case $percent_translated <= 25 && $num_strings > $warning_threshold:
+		case ( $percent_translated <= 25 && $num_strings > $warning_threshold ) :
 			$summary .= "Only {$percent_translated}% already translated.";
 			break;
-		case $percent_translated <= 25:
+		case '0' === $percent_translated :
+			$summary .= "Nothing translated yet.";
+			break;
+		default :
 			$summary .= "{$percent_translated}% already translated.";
 			break;
-		case $percent_translated === '0':
-			$summary .= "Nothing translated yet.";
 	}
 
 	return $summary;

--- a/includes/localci-functions.php
+++ b/includes/localci-functions.php
@@ -53,17 +53,16 @@ function localci_generate_coverage_summary( $num_strings, $new_strings = 0, $per
 		case ( 0 === $num_strings ) :
 			break;
 		case '100' === $percent_translated :
-			$summary .= 'Translations: 100% coverage.';
-			break;
-		case $percent_translated >= 75:
-			$summary .= "Translations: {$percent_translated}% coverage.";
+			$summary .= 'Everything already translated!';
 			break;
 		case $percent_translated > 25:
-			$summary .= "Translations: {$percent_translated}% coverage.";
+			$summary .= "{$percent_translated}% already translated.";
 			break;
 		case $percent_translated <= 25:
-			$prefix = ( $num_strings > $warning_threshold && '0' !== $percent_translated ) ? ' Only ' : ' Translations: ';
-			$summary .= $prefix . "{$percent_translated}% translated.";
+			$prefix = ( $num_strings > $warning_threshold ) ? ' Only ' : '';
+			$summary .= $prefix . "{$percent_translated}% already translated.";
+		case $percent_translated === '0':
+			$summary .= "Nothing translated yet.";
 	}
 
 	return $summary;


### PR DESCRIPTION
I think the current wording "Total: x strings. Translations: x% coverage" can be confusing. What does coverage mean? I changed the wording to "x% already translated" which makes it very clear what's going on.